### PR TITLE
TypeScript: support custom Error type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,9 @@
 /**
 Create an error from multiple errors.
 */
-declare class AggregateError extends Error implements Iterable<Error> {
-	readonly name: 'AggregateError';
+declare class AggregateError<T extends Error = Error> extends Error
+	implements Iterable<T> {
+	readonly name: "AggregateError";
 
 	/**
 	@param errors - If a string, a new `Error` is created with the string as the error message. If a non-Error object, a new `Error` is created with all properties from the object copied over.
@@ -43,9 +44,9 @@ declare class AggregateError extends Error implements Iterable<Error> {
 	//=> [Error: baz]
 	```
 	*/
-	constructor(errors: ReadonlyArray<Error | {[key: string]: any} | string>);
+	constructor(errors: ReadonlyArray<T | { [key: string]: any } | string>);
 
-	[Symbol.iterator](): IterableIterator<Error>;
+	[Symbol.iterator](): IterableIterator<T>;
 }
 
 export = AggregateError;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,14 +1,25 @@
-import {expectType} from 'tsd';
-import AggregateError = require('.');
+import { expectType } from "tsd";
+import AggregateError = require(".");
 
 const aggregateError = new AggregateError([
-	new Error('foo'),
-	{foo: 'bar'},
-	'bar'
+	new Error("foo"),
+	{ foo: "bar" },
+	"bar"
 ]);
 expectType<Iterable<Error>>(aggregateError);
 expectType<IterableIterator<Error>>(aggregateError[Symbol.iterator]());
 
 for (const error of aggregateError) {
 	expectType<Error>(error);
+}
+
+interface CustomError extends Error {
+	foo: string;
+}
+const customAggregateError = new AggregateError<CustomError>([
+	new Error("foo")
+]);
+
+for (const error of customAggregateError) {
+	expectType<string>(error.foo);
 }


### PR DESCRIPTION
First of all thanks for the great library! We use it in `semantic-release` and love it!

I'm now looking into using it in [`@octokit/webhooks`](https://github.com/octokit/webhooks) in order to address https://github.com/octokit/webhooks.js/issues/182

We use a custom Error type for request errors, which are the most common error types in webhook event handlers, so I'd like to provide better intellisense when users interact with the errors from the AggregatedError array. In order to make that possible, the Error type used by would need to be customizeable. That's what I do in this pull request.

Sorry for not opening an issue first, I figured it would be easier to reason about the implementation details in a pull request